### PR TITLE
Move first workflows from napari/napari

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "ci(dependabot):"
+    labels:
+      - "maintenance"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -1,0 +1,36 @@
+name: Clean up PR description
+
+on:
+  # see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+  workflow_call:
+# see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+permissions:
+  pull-requests: write
+
+jobs:
+  check_labels:
+    name: Remove html comments
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: napari/napari
+      # install python and requests
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+      - name: Remove html comments
+        env:
+          GH_PR_NUMBER: ${{ github.event.number }}
+          GH_REPO_URL: ${{ github.event.repository.url}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        run: |
+          uv run --script scripts/remove_html_comments_from_pr.py

--- a/.github/workflows/edit_pr_description.yml
+++ b/.github/workflows/edit_pr_description.yml
@@ -18,12 +18,12 @@ jobs:
     name: Remove html comments
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: napari/napari
       # install python and requests
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
       - name: Remove html comments

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,0 +1,34 @@
+name: Remove "ready to merge" label
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_call:
+
+
+permissions:
+  pull-requests: write
+
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const { owner, repo, number: pull_number } = context.issue;
+            const { data: pullRequest } = await github.rest.pulls.get({ owner, repo, pull_number });
+            if (!pullRequest.merged) {
+              console.log("Pull request not merged, skipping.");
+              return;
+            }
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pull_number });
+            const labelToRemove = labels.find(label => label.name === "ready to merge");
+            if (!labelToRemove) {
+              console.log("Label not found on pull request, skipping.");
+              return;
+            }
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name: "ready to merge" });
+            console.log("Label removed.");

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -1,11 +1,7 @@
 name: Remove "ready to merge" label
 
 on:
-  pull_request_target:
-    types: [closed]
   workflow_call:
-
-
 permissions:
   pull-requests: write
 
@@ -16,19 +12,31 @@ jobs:
       - name: Remove label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const { owner, repo, number: pull_number } = context.issue;
-            const { data: pullRequest } = await github.rest.pulls.get({ owner, repo, pull_number });
-            if (!pullRequest.merged) {
-              console.log("Pull request not merged, skipping.");
-              return;
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'closed',
+              per_page: 100,
+              sort: 'updated',
+              direction: 'desc',
+              labels: 'ready to merge',
+            });
+            if (issues.length > 0) {
+              console.log('Found the following closed items with the "ready to merge" label:');
+              for (const issue of issues) {
+                console.log(`- #${issue.number}: ${issue.title}`);
+                try {
+                  await github.rest.issues.removeLabel({
+                    ...context.repo,
+                    issue_number: issue.number,
+                    name: 'ready to merge'
+                  });
+                  console.log(`  > Removed 'ready to merge' label from #${issue.number}`);
+                } catch (error) {
+                  console.error(`  > Failed to remove label from #${issue.number}: ${error.message}`);
+                }
+              }
+            } else {
+              console.log('No closed items found with the "ready to merge" label.');
             }
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({ owner, repo, issue_number: pull_number });
-            const labelToRemove = labels.find(label => label.name === "ready to merge");
-            if (!labelToRemove) {
-              console.log("Label not found on pull request, skipping.");
-              return;
-            }
-            await github.rest.issues.removeLabel({ owner, repo, issue_number: pull_number, name: "ready to merge" });
-            console.log("Label removed.");

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -2,6 +2,12 @@ name: Remove "ready to merge" label
 
 on:
   workflow_call:
+    inputs:
+      label_name:
+        description: 'The name of the label to remove from closed items'
+        required: false
+        default: 'ready to merge'
+
 permissions:
   pull-requests: write
 
@@ -10,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Remove label
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -20,7 +26,7 @@ jobs:
               per_page: 100,
               sort: 'updated',
               direction: 'desc',
-              labels: 'ready to merge',
+              labels: ${{ inputs.label_name || 'ready to merge' }},
             });
             if (issues.length > 0) {
               console.log('Found the following closed items with the "ready to merge" label:');

--- a/scripts/remove_html_comments_from_pr.py
+++ b/scripts/remove_html_comments_from_pr.py
@@ -1,0 +1,97 @@
+
+# /// script
+# dependencies = [
+#   "requests"
+# ]
+# requires-python = ">=3.11"
+# ///
+"""
+Edit pull request description to remove HTML comments
+
+We might want to remove section with markdown task lists that are completely empty
+"""
+
+import re
+import sys
+from os import environ
+
+import requests
+
+REPO = 'napari/napari'
+
+
+def remove_html_comments(text):
+    # Regular expression to remove HTML comments
+    # [^\S\r\n] is whitespace but not new line
+    html_comment_pattern = r'[^\S\r\n]*<!--(.*?)-->[^\S\r\n]*\s*'
+    return re.sub(html_comment_pattern, '\n', text, flags=re.DOTALL)
+
+
+def edit_pull_request_description(repo, pull_request_number, access_token):
+    # GitHub API base URL
+    base_url = 'https://api.github.com'
+
+    # Prepare the headers with the access token
+    headers = {'Authorization': f'token {access_token}'}
+
+    # Get the current pull request description
+    pr_url = f'{base_url}/repos/{repo}/pulls/{pull_request_number}'
+    response = requests.get(pr_url, headers=headers)
+    response.raise_for_status()
+    response_json = response.json()
+    current_description = response_json['body']
+
+    # Remove HTML comments from the description
+    edited_description = remove_html_comments(current_description)
+
+    if edited_description == current_description:
+        print('No HTML comments found in the pull request description')
+        return
+
+    # Update the pull request description
+    update_pr_url = f'{base_url}/repos/{repo}/pulls/{pull_request_number}'
+    payload = {'body': edited_description}
+    response = requests.patch(update_pr_url, json=payload, headers=headers)
+    response.raise_for_status()
+
+    if response.status_code == 200:
+        print(
+            f'Pull request #{pull_request_number} description has been updated successfully!'
+        )
+    else:
+        print(
+            f'Failed to update pull request description. Status code: {response.status_code}'
+        )
+
+
+if __name__ == '__main__':
+    print('Will inspect PR description to remove html comments.')
+
+    # note that the env between pull_request and pull_request_target are different
+    # and the github documentation is incorrect (or at least misleading)
+    # and likely varies between pull request intra-repository and inter-repository
+    # thus we log many things to try to understand what is going on in case of failure.
+    # among other:
+    # - github.event.repository.name is not the full slug, but just the name
+    # - github.event.repository.org is empty if the repo is a normal user.
+
+    repository_url = environ.get('GH_REPO_URL')
+    print(f'Current repository is {repository_url}')
+    repository_parts = repository_url.split('/')[-2:]
+
+    slug = '/'.join(repository_parts)
+    print(f'Current slug is {slug}')
+    if slug != REPO:
+        print('Not on main repo, aborting with success')
+        sys.exit(0)
+
+    # get current PR number from github actions
+    number = environ.get('GH_PR_NUMBER')
+    print(f'Current PR number is {number}')
+
+    access_token = environ.get('GH_TOKEN')
+    if access_token is None:
+        print('No access token found in the environment variables')
+        # we still don't want fail status
+        sys.exit(0)
+    edit_pull_request_description(slug, number, access_token)


### PR DESCRIPTION
Copy two workflows from the napari repository:

* `edit_pr_description.yml`
* `remove_ready_to_merge.yml` 

It is the first PR to allow unified workflows across organizations with the ability to pin older versions for less used repositories, where Dependabot will trigger PR and allow us solve some problems.