### PR TITLE
Fix: Use env var for labels: in remove label job

### DIFF
--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -27,7 +27,7 @@ jobs:
               per_page: 100,
               sort: 'updated',
               direction: 'desc',
-              labels: ${{ inputs.label_name || 'ready to merge' }},
+              labels: '${{ inputs.label_name || 'ready to merge' }}',
             });
             if (issues.length > 0) {
               console.log('Found the following closed items with the "ready to merge" label:');

--- a/.github/workflows/remove_ready_to_merge.yml
+++ b/.github/workflows/remove_ready_to_merge.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Remove label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v7.0.1
+        env:
+          LABEL_NAME: ${{ inputs.label_name || 'ready to merge' }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -27,7 +29,7 @@ jobs:
               per_page: 100,
               sort: 'updated',
               direction: 'desc',
-              labels: '${{ inputs.label_name || 'ready to merge' }}',
+              labels: process.env.LABEL_NAME,
             });
             if (issues.length > 0) {
               console.log('Found the following closed items with the "ready to merge" label:');


### PR DESCRIPTION
Action fails daily in my notifs for napari/docs: https://github.com/napari/docs/actions/runs/28849007810
It seems like the `inputs.label_name` is interpreted as individul identifiers. These quotes should make it so that labels gets treated as a string, so `labels: 'Full docs preview/ready to merge'` will now work instead of the bare expression `labels: Full docs preview/ready to merge`.

```
Run actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
  with:
    github-token: ***
    script: const { data: issues } = await github.rest.issues.listForRepo({
    ...context.repo,
    state: 'closed',
    per_page: 100,
    sort: 'updated',
    direction: 'desc',
    labels: Full docs preview/ready to merge,
  });
  if (issues.length > 0) {
    console.log('Found the following closed items with the "ready to merge" label:');
    for (const issue of issues) {
      console.log(`- #${issue.number}: ${issue.title}`);
      try {
        await github.rest.issues.removeLabel({
          ...context.repo,
          issue_number: issue.number,
          name: 'ready to merge'
        });
        console.log(`  > Removed 'ready to merge' label from #${issue.number}`);
      } catch (error) {
        console.error(`  > Failed to remove label from #${issue.number}: ${error.message}`);
      }
    }
  } else {
    console.log('No closed items found with the "ready to merge" label.');
  }
  
    debug: false
    user-agent: actions/github-script
    result-encoding: json
    retries: 0
    retry-exempt-status-codes: 400,401,403,404,422
SyntaxError: Unexpected identifier 'docs'
```